### PR TITLE
Support needs-hash annotation value and add tests

### DIFF
--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -232,6 +232,11 @@ func (r *Resource) AsYAML() ([]byte, error) {
 	return yaml.JSONToYAML(json)
 }
 
+// SetOptions updates the generator options for the resource.
+func (r *Resource) SetOptions(o *types.GenArgs) {
+	r.options = o
+}
+
 // Behavior returns the behavior for the resource.
 func (r *Resource) Behavior() types.GenerationBehavior {
 	return r.options.Behavior()

--- a/pkg/target/kusttarget.go
+++ b/pkg/target/kusttarget.go
@@ -260,7 +260,6 @@ func (kt *KustTarget) runGenerators(
 		if err != nil {
 			return err
 		}
-		// The legacy generators allow override.
 		err = ra.AbsorbAll(resMap)
 		if err != nil {
 			return errors.Wrapf(err, "merging from generator %v", g)
@@ -275,7 +274,7 @@ func (kt *KustTarget) runGenerators(
 		if err != nil {
 			return err
 		}
-		err = ra.AppendAll(resMap)
+		err = ra.AbsorbAll(resMap)
 		if err != nil {
 			return errors.Wrapf(err, "merging from generator %v", g)
 		}

--- a/plugin/execannotations_test.go
+++ b/plugin/execannotations_test.go
@@ -1,0 +1,62 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"testing"
+
+	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
+	plugins_test "sigs.k8s.io/kustomize/v3/pkg/plugins/test"
+	"sigs.k8s.io/kustomize/v3/pkg/types"
+)
+
+func TestNeedsHashAnnotation(t *testing.T) {
+	tc := plugins_test.NewEnvForTest(t).Set()
+	defer tc.Reset()
+
+	tc.BuildExecPlugin(
+		"someteam.example.com", "v1", "TestGenerator")
+
+	th := kusttest_test.NewKustTestPluginHarness(t, "/app")
+
+	rm := th.LoadAndRunGenerator(`
+apiVersion: someteam.example.com/v1
+kind: TestGenerator
+metadata:
+  name: whatever
+  annotations:
+    kustomize.config.k8s.io/needs-hash: "true"
+`)
+
+	for _, r := range rm.Resources() {
+		if !r.NeedHashSuffix() {
+			t.Fatalf("resources should need hash suffix: %v", r)
+		}
+	}
+}
+
+func TestBehaviorAnnotation(t *testing.T) {
+	tc := plugins_test.NewEnvForTest(t).Set()
+	defer tc.Reset()
+
+	tc.BuildExecPlugin(
+		"someteam.example.com", "v1", "TestGenerator")
+
+	th := kusttest_test.NewKustTestPluginHarness(t, "/app")
+
+	rm := th.LoadAndRunGenerator(`
+apiVersion: someteam.example.com/v1
+kind: TestGenerator
+metadata:
+  name: whatever
+  annotations:
+    kustomize.config.k8s.io/behavior: "merge"
+`)
+
+	for _, r := range rm.Resources() {
+		if r.Behavior() != types.BehaviorMerge {
+			t.Fatalf("resources should have behavior merge: %v", r)
+		}
+	}
+}

--- a/plugin/someteam.example.com/v1/testgenerator/TestGenerator
+++ b/plugin/someteam.example.com/v1/testgenerator/TestGenerator
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Dummy generator used for testing. Passes the input unchanged.
+
+cat "$1"

--- a/plugin/someteam.example.com/v1/testgenerator/TestGenerator_test.go
+++ b/plugin/someteam.example.com/v1/testgenerator/TestGenerator_test.go
@@ -1,0 +1,34 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package main_test
+
+import (
+	"testing"
+
+	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
+	plugins_test "sigs.k8s.io/kustomize/v3/pkg/plugins/test"
+)
+
+func TestTestGeneratorPlugin(t *testing.T) {
+	tc := plugins_test.NewEnvForTest(t).Set()
+	defer tc.Reset()
+
+	tc.BuildExecPlugin(
+		"someteam.example.com", "v1", "TestGenerator")
+
+	th := kusttest_test.NewKustTestPluginHarness(t, "/app")
+
+	m := th.LoadAndRunGenerator(`
+apiVersion: someteam.example.com/v1
+kind: TestGenerator
+metadata:
+  name: whatever
+`)
+	th.AssertActualEqualsExpected(m, `
+apiVersion: someteam.example.com/v1
+kind: TestGenerator
+metadata:
+  name: whatever
+`)
+}


### PR DESCRIPTION
This makes the "kustomize.config.k8s.io/needs-hash" annotation support non-true values and adds tests to your kustomize PR.

This is mainly to save you effort. Feel free to disregard and use your own work.